### PR TITLE
Update config.cpp to grab latest frame by default

### DIFF
--- a/src/internal/config.cpp
+++ b/src/internal/config.cpp
@@ -27,7 +27,8 @@ Config::Config()
   m_cfg->ledc_channel = LEDC_CHANNEL_0;
   m_cfg->pixel_format = PIXFORMAT_RGB565;
   m_cfg->frame_size = FRAMESIZE_QQVGA;
-  m_cfg->fb_count = 1;
+  m_cfg->fb_count = 2;
+  m_cfg->grab_mode = CAMERA_GRAB_LATEST;
 }
 
 Config::~Config()


### PR DESCRIPTION
This changes will make sure the camera will always capture the latest frame.